### PR TITLE
[INTERNAL] Add postinstall script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "description": "",
   "version": "1.0.0",
   "private": true,
+  "scripts": {
+    "postinstall": "grunt"
+  },
   "devDependencies": {
     "grunt": "~0.4.2",
     "grunt-contrib-compass": "~0.7.0",


### PR DESCRIPTION
This PR adds a postinstall script hook to **package.json**. The hook runs the command `grunt`, which will build the distribution files whenever `npm install` is run.