### PR TITLE
[INTERNAL] Change tabs to spaces in .editorconfig and update files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,13 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
 # editorconfig.org
+
 root = true
 
+
 [*]
-indent_style = tab
+indent_style = space
+indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,151 +1,151 @@
 /*jshint node: true */
 
 module.exports = function(grunt) {
-	'use strict';
+  'use strict';
 
-	grunt.initConfig({
-		pkg: grunt.file.readJSON('package.json'),
+  grunt.initConfig({
+    pkg: grunt.file.readJSON('package.json'),
 
-		banner: '/** \n' +
-			' * Automatically Generated - DO NOT EDIT \n' +
-			' * <%= pkg.name %> / v<%= pkg.version %> / <%= grunt.template.today("yyyy-mm-dd") %> \n' +
-			' */ \n\n',
+    banner: '/** \n' +
+      ' * Automatically Generated - DO NOT EDIT \n' +
+      ' * <%= pkg.name %> / v<%= pkg.version %> / <%= grunt.template.today("yyyy-mm-dd") %> \n' +
+      ' */ \n\n',
 
-		sourcePath: 'src',
-		distPath: 'dist',
-		templateDir: 'templates',
-		assetDir: 'assets',
+    sourcePath: 'src',
+    distPath: 'dist',
+    templateDir: 'templates',
+    assetDir: 'assets',
 
-		watch: {
-			js: {
-				files: '<%= sourcePath %>/<%= assetDir %>/js/*.js',
-				tasks: ['uglify:js', 'copy:assets']
-			},
-			jsPlugins: {
-				files: ['<%= sourcePath %>/<%= assetDir %>/js/vendor/**/*.js', '!<%= sourcePath %>/<%= assetDir %>/js/vendor/min/*.js'],
-				tasks: ['uglify:jsPlugins', 'copy:assets']
-			},
-			sass: {
-				files: '<%= sourcePath %>/<%= assetDir %>/scss/**/*.scss',
-				tasks: ['compass:dist', 'copy:assets', 'usebanner']
-			},
-			html: {
-				files: '<%= sourcePath %>/<%= templateDir %>/**/*.hbs',
-				tasks: ['assemble', 'prettify:dist']
-			}
-		},
+    watch: {
+      js: {
+        files: '<%= sourcePath %>/<%= assetDir %>/js/*.js',
+        tasks: ['uglify:js', 'copy:assets']
+      },
+      jsPlugins: {
+        files: ['<%= sourcePath %>/<%= assetDir %>/js/vendor/**/*.js', '!<%= sourcePath %>/<%= assetDir %>/js/vendor/min/*.js'],
+        tasks: ['uglify:jsPlugins', 'copy:assets']
+      },
+      sass: {
+        files: '<%= sourcePath %>/<%= assetDir %>/scss/**/*.scss',
+        tasks: ['compass:dist', 'copy:assets', 'usebanner']
+      },
+      html: {
+        files: '<%= sourcePath %>/<%= templateDir %>/**/*.hbs',
+        tasks: ['assemble', 'prettify:dist']
+      }
+    },
 
-		compass: {
-			dist: {
-				options: {
-					config: 'config.rb'
-				}
-			}
-		},
+    compass: {
+      dist: {
+        options: {
+          config: 'config.rb'
+        }
+      }
+    },
 
-		uglify: {
-			js: {
-				options : {
-					banner: '<%= banner %>',
-					beautify : {
-						ascii_only : true,
-						quote_keys: true
-					}
-				},
-				files: [{
-					expand: true,
-					cwd: '<%= sourcePath %>/<%= assetDir %>/js',
-					src: '*.js',
-					dest: '<%= sourcePath %>/<%= assetDir %>/js/min'
-				}]
-			},
-			jsPlugins: {
-				options : {
-					beautify : {
-						ascii_only : true,
-						quote_keys: true
-					}
-				},
-				files: {
-					'<%= sourcePath %>/<%= assetDir %>/js/vendor/min/plugins.js': ['<%= sourcePath %>/<%= assetDir %>/js/vendor/**/*.js', '!<%= sourcePath %>/<%= assetDir %>/js/vendor/min/*.js'],
-				}
-			}
-		},
+    uglify: {
+      js: {
+        options : {
+          banner: '<%= banner %>',
+          beautify : {
+            ascii_only : true,
+            quote_keys: true
+          }
+        },
+        files: [{
+          expand: true,
+          cwd: '<%= sourcePath %>/<%= assetDir %>/js',
+          src: '*.js',
+          dest: '<%= sourcePath %>/<%= assetDir %>/js/min'
+        }]
+      },
+      jsPlugins: {
+        options : {
+          beautify : {
+            ascii_only : true,
+            quote_keys: true
+          }
+        },
+        files: {
+          '<%= sourcePath %>/<%= assetDir %>/js/vendor/min/plugins.js': ['<%= sourcePath %>/<%= assetDir %>/js/vendor/**/*.js', '!<%= sourcePath %>/<%= assetDir %>/js/vendor/min/*.js'],
+        }
+      }
+    },
 
-		smushit: {
-			dist: {
-				src:  ['<%= sourcePath %>/<%= assetDir %>/img/**/*.png', '<%= sourcePath %>/<%= assetDir %>/img/**/*.jpg'],
-				dest: '<%= distPath %>/<%= assetDir %>/img'
-			}
-		},
+    smushit: {
+      dist: {
+        src:  ['<%= sourcePath %>/<%= assetDir %>/img/**/*.png', '<%= sourcePath %>/<%= assetDir %>/img/**/*.jpg'],
+        dest: '<%= distPath %>/<%= assetDir %>/img'
+      }
+    },
 
-		usebanner: {
-			screenCSS: {
-				options: {
-					position: 'top',
-					banner: '<%= banner %>',
-					linebreak: true
-				},
-				files: {
-					src: [ '<%= distPath %>/<%= assetDir %>/css/*.css' ]
-				}
-			}
-		},
+    usebanner: {
+      screenCSS: {
+        options: {
+          position: 'top',
+          banner: '<%= banner %>',
+          linebreak: true
+        },
+        files: {
+          src: [ '<%= distPath %>/<%= assetDir %>/css/*.css' ]
+        }
+      }
+    },
 
-		assemble: {
-		  options: {
-				assets: '<%= distPath %>/<%= assetDir %>',
-				layoutdir: '<%= sourcePath %>/<%= templateDir %>/layouts',
-				partials: ['<%= sourcePath %>/<%= templateDir %>/partials/**/*.hbs'],
-				flatten: true,
-		  },
-		  site: {
-				options: {
-					layout: 'default.hbs'
-				},
-				src: ['<%= sourcePath %>/<%= templateDir %>/*.hbs'],
-				dest: '<%= distPath %>'
-		  }
-		},
+    assemble: {
+      options: {
+        assets: '<%= distPath %>/<%= assetDir %>',
+        layoutdir: '<%= sourcePath %>/<%= templateDir %>/layouts',
+        partials: ['<%= sourcePath %>/<%= templateDir %>/partials/**/*.hbs'],
+        flatten: true,
+      },
+      site: {
+        options: {
+          layout: 'default.hbs'
+        },
+        src: ['<%= sourcePath %>/<%= templateDir %>/*.hbs'],
+        dest: '<%= distPath %>'
+      }
+    },
 
-		copy: {
-			assets: {
-				files: [{
-					expand: true,
-					cwd: '<%= sourcePath %>/<%= assetDir %>/',
-					src: ['**', '!scss/**'],
-					dest: '<%= distPath %>/<%= assetDir %>/'
-				}]
-			}
-		},
+    copy: {
+      assets: {
+        files: [{
+          expand: true,
+          cwd: '<%= sourcePath %>/<%= assetDir %>/',
+          src: ['**', '!scss/**'],
+          dest: '<%= distPath %>/<%= assetDir %>/'
+        }]
+      }
+    },
 
-		prettify: {
-			options: {
-				indent: 1,
-				indent_char: '  ',
-				brace_style: 'expand',
-				unformatted: ['a', 'code', 'pre']
-			},
-			dist: {
-				expand: true,
-				cwd: '<%= distPath %>',
-				ext: '.html',
-				src: ['*.html'],
-				dest: '<%= distPath %>'
-			}
-		}
+    prettify: {
+      options: {
+        indent: 1,
+        indent_char: '  ',
+        brace_style: 'expand',
+        unformatted: ['a', 'code', 'pre']
+      },
+      dist: {
+        expand: true,
+        cwd: '<%= distPath %>',
+        ext: '.html',
+        src: ['*.html'],
+        dest: '<%= distPath %>'
+      }
+    }
 
-	});
+  });
 
-	grunt.loadNpmTasks('grunt-contrib-compass');
-	grunt.loadNpmTasks('grunt-contrib-watch');
-	grunt.loadNpmTasks('grunt-contrib-uglify');
-	grunt.loadNpmTasks('grunt-contrib-copy');
-	grunt.loadNpmTasks('grunt-prettify');
-	grunt.loadNpmTasks('grunt-banner');
-	grunt.loadNpmTasks('grunt-smushit');
-	grunt.loadNpmTasks('assemble');
+  grunt.loadNpmTasks('grunt-contrib-compass');
+  grunt.loadNpmTasks('grunt-contrib-watch');
+  grunt.loadNpmTasks('grunt-contrib-uglify');
+  grunt.loadNpmTasks('grunt-contrib-copy');
+  grunt.loadNpmTasks('grunt-prettify');
+  grunt.loadNpmTasks('grunt-banner');
+  grunt.loadNpmTasks('grunt-smushit');
+  grunt.loadNpmTasks('assemble');
 
-	grunt.registerTask('default', ['uglify', 'compass', 'assemble', 'prettify:dist', 'copy:assets', 'usebanner']);
+  grunt.registerTask('default', ['uglify', 'compass', 'assemble', 'prettify:dist', 'copy:assets', 'usebanner']);
 
 };

--- a/src/assets/js/global.js
+++ b/src/assets/js/global.js
@@ -1,7 +1,7 @@
 /* global jQuery */
 
 (function ($) {
-	'use strict';
+  'use strict';
 
 
 })(jQuery);

--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -3,7 +3,6 @@ $color-white: #ffffff;
 $color-black: #000000;
 
 
-
 // Font weights
 $font-weight-light: 300;
 $font-weight-regular: 400;

--- a/src/assets/scss/elements/_normalize.scss
+++ b/src/assets/scss/elements/_normalize.scss
@@ -20,7 +20,7 @@ main,
 nav,
 section,
 summary {
-    display: block;
+  display: block;
 }
 
 /**
@@ -30,7 +30,7 @@ summary {
 audio,
 canvas,
 video {
-    display: inline-block;
+  display: inline-block;
 }
 
 /**
@@ -39,8 +39,8 @@ video {
  */
 
 audio:not([controls]) {
-    display: none;
-    height: 0;
+  display: none;
+  height: 0;
 }
 
 /**
@@ -50,7 +50,7 @@ audio:not([controls]) {
 
 [hidden],
 template {
-    display: none;
+  display: none;
 }
 
 /* ==========================================================================
@@ -64,9 +64,9 @@ template {
  */
 
 html {
-    font-family: sans-serif; /* 1 */
-    -ms-text-size-adjust: 100%; /* 2 */
-    -webkit-text-size-adjust: 100%; /* 2 */
+  font-family: sans-serif; /* 1 */
+  -ms-text-size-adjust: 100%; /* 2 */
+  -webkit-text-size-adjust: 100%; /* 2 */
 }
 
 /**
@@ -74,7 +74,7 @@ html {
  */
 
 body {
-    margin: 0;
+  margin: 0;
 }
 
 /* ==========================================================================
@@ -86,7 +86,7 @@ body {
  */
 
 a {
-    background: transparent;
+  background: transparent;
 }
 
 /**
@@ -94,7 +94,7 @@ a {
  */
 
 a:focus {
-    outline: thin dotted;
+  outline: thin dotted;
 }
 
 /**
@@ -103,7 +103,7 @@ a:focus {
 
 a:active,
 a:hover {
-    outline: 0;
+  outline: 0;
 }
 
 /* ==========================================================================
@@ -116,8 +116,8 @@ a:hover {
  */
 
 h1 {
-    font-size: 2em;
-    margin: 0.67em 0;
+  font-size: 2em;
+  margin: 0.67em 0;
 }
 
 /**
@@ -125,7 +125,7 @@ h1 {
  */
 
 abbr[title] {
-    border-bottom: 1px dotted;
+  border-bottom: 1px dotted;
 }
 
 /**
@@ -134,7 +134,7 @@ abbr[title] {
 
 b,
 strong {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 /**
@@ -142,7 +142,7 @@ strong {
  */
 
 dfn {
-    font-style: italic;
+  font-style: italic;
 }
 
 /**
@@ -150,9 +150,9 @@ dfn {
  */
 
 hr {
-    -moz-box-sizing: content-box;
-    box-sizing: content-box;
-    height: 0;
+  -moz-box-sizing: content-box;
+  box-sizing: content-box;
+  height: 0;
 }
 
 /**
@@ -160,8 +160,8 @@ hr {
  */
 
 mark {
-    background: #ff0;
-    color: #000;
+  background: #ff0;
+  color: #000;
 }
 
 /**
@@ -172,8 +172,8 @@ code,
 kbd,
 pre,
 samp {
-    font-family: monospace, serif;
-    font-size: 1em;
+  font-family: monospace, serif;
+  font-size: 1em;
 }
 
 /**
@@ -181,7 +181,7 @@ samp {
  */
 
 pre {
-    white-space: pre-wrap;
+  white-space: pre-wrap;
 }
 
 /**
@@ -189,7 +189,7 @@ pre {
  */
 
 q {
-    quotes: "\201C" "\201D" "\2018" "\2019";
+  quotes: "\201C" "\201D" "\2018" "\2019";
 }
 
 /**
@@ -197,7 +197,7 @@ q {
  */
 
 small {
-    font-size: 80%;
+  font-size: 80%;
 }
 
 /**
@@ -206,18 +206,18 @@ small {
 
 sub,
 sup {
-    font-size: 75%;
-    line-height: 0;
-    position: relative;
-    vertical-align: baseline;
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
 }
 
 sup {
-    top: -0.5em;
+  top: -0.5em;
 }
 
 sub {
-    bottom: -0.25em;
+  bottom: -0.25em;
 }
 
 /* ==========================================================================
@@ -229,7 +229,7 @@ sub {
  */
 
 img {
-    border: 0;
+  border: 0;
 }
 
 /**
@@ -237,7 +237,7 @@ img {
  */
 
 svg:not(:root) {
-    overflow: hidden;
+  overflow: hidden;
 }
 
 /* ==========================================================================
@@ -249,7 +249,7 @@ svg:not(:root) {
  */
 
 figure {
-    margin: 0;
+  margin: 0;
 }
 
 /* ==========================================================================
@@ -261,9 +261,9 @@ figure {
  */
 
 fieldset {
-    border: 1px solid #c0c0c0;
-    margin: 0 2px;
-    padding: 0.35em 0.625em 0.75em;
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em;
 }
 
 /**
@@ -272,8 +272,8 @@ fieldset {
  */
 
 legend {
-    border: 0; /* 1 */
-    padding: 0; /* 2 */
+  border: 0; /* 1 */
+  padding: 0; /* 2 */
 }
 
 /**
@@ -286,9 +286,9 @@ button,
 input,
 select,
 textarea {
-    font-family: inherit; /* 1 */
-    font-size: 100%; /* 2 */
-    margin: 0; /* 3 */
+  font-family: inherit; /* 1 */
+  font-size: 100%; /* 2 */
+  margin: 0; /* 3 */
 }
 
 /**
@@ -298,7 +298,7 @@ textarea {
 
 button,
 input {
-    line-height: normal;
+  line-height: normal;
 }
 
 /**
@@ -310,7 +310,7 @@ input {
 
 button,
 select {
-    text-transform: none;
+  text-transform: none;
 }
 
 /**
@@ -325,8 +325,8 @@ button,
 html input[type="button"], /* 1 */
 input[type="reset"],
 input[type="submit"] {
-    -webkit-appearance: button; /* 2 */
-    cursor: pointer; /* 3 */
+  -webkit-appearance: button; /* 2 */
+  cursor: pointer; /* 3 */
 }
 
 /**
@@ -335,7 +335,7 @@ input[type="submit"] {
 
 button[disabled],
 html input[disabled] {
-    cursor: default;
+  cursor: default;
 }
 
 /**
@@ -345,8 +345,8 @@ html input[disabled] {
 
 input[type="checkbox"],
 input[type="radio"] {
-    box-sizing: border-box; /* 1 */
-    padding: 0; /* 2 */
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
 }
 
 /**
@@ -356,10 +356,10 @@ input[type="radio"] {
  */
 
 input[type="search"] {
-    -webkit-appearance: textfield; /* 1 */
-    -moz-box-sizing: content-box;
-    -webkit-box-sizing: content-box; /* 2 */
-    box-sizing: content-box;
+  -webkit-appearance: textfield; /* 1 */
+  -moz-box-sizing: content-box;
+  -webkit-box-sizing: content-box; /* 2 */
+  box-sizing: content-box;
 }
 
 /**
@@ -369,7 +369,7 @@ input[type="search"] {
 
 input[type="search"]::-webkit-search-cancel-button,
 input[type="search"]::-webkit-search-decoration {
-    -webkit-appearance: none;
+  -webkit-appearance: none;
 }
 
 /**
@@ -378,8 +378,8 @@ input[type="search"]::-webkit-search-decoration {
 
 button::-moz-focus-inner,
 input::-moz-focus-inner {
-    border: 0;
-    padding: 0;
+  border: 0;
+  padding: 0;
 }
 
 /**
@@ -388,8 +388,8 @@ input::-moz-focus-inner {
  */
 
 textarea {
-    overflow: auto; /* 1 */
-    vertical-align: top; /* 2 */
+  overflow: auto; /* 1 */
+  vertical-align: top; /* 2 */
 }
 
 /* ==========================================================================
@@ -401,6 +401,6 @@ textarea {
  */
 
 table {
-    border-collapse: collapse;
-    border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }

--- a/src/assets/scss/screen.scss
+++ b/src/assets/scss/screen.scss
@@ -1,20 +1,20 @@
 @charset "UTF-8";
 
 // Main imports
-@import "compass",
-       	"elements/normalize";
+@import "compass";
+@import "elements/normalize";
 
 // Variables/Mixins/Functions
-@import "variables",
-        "utilities/utilities";
+@import "variables";
+@import "utilities/utilities";
 
 // CSS framework
 @import "foundation/foundation";
 
 // Site elements
-@import "elements/font-icons",
-        "elements/buttons",
-        "elements/forms";
+@import "elements/font-icons";
+@import "elements/buttons";
+@import "elements/forms";
 
 // Global styles
 @import "global";

--- a/src/assets/scss/utilities/_functions.scss
+++ b/src/assets/scss/utilities/_functions.scss
@@ -1,21 +1,20 @@
 // General font size function that will convert integers into em values
 // font-size: em(12);
 @function em($target, $context: $base_font_size) {
-    @if type-of($target) == "number" {
-        @return ($target / $context) * 1em;
+  @if type-of($target) == "number" {
+    @return ($target / $context) * 1em;
+  } @else {
+    $em-values: unquote("");
+    @each $value in $target {
+      // If the value is zero, return 0
+      @if $value == 0 {
+        $em-values: append($em-values, $value);
+      } @else {
+        $em-values: append($em-values, ($value / $context) * 1em);
+      }
     }
-    @else {
-        $em-values: unquote("");
-        @each $value in $target {
-            // If the value is zero, return 0
-            @if $value == 0 {
-                $em-values: append($em-values, $value);
-            } @else {
-                $em-values: append($em-values, ($value / $context) * 1em);
-            }
-        }
-        @return $em-values;
-    }
+    @return $em-values;
+  }
 }
 
 @function rem($target, $context: $base_font_size) {

--- a/src/assets/scss/utilities/_mixins.scss
+++ b/src/assets/scss/utilities/_mixins.scss
@@ -1,12 +1,12 @@
 @mixin inline-block {
-    display:inline-block;
-    *display:inline;
-    zoom:1;
+  display:inline-block;
+  *display:inline;
+  zoom:1;
 }
 
 @mixin fontfix {
-    -webkit-font-smoothing: antialiased;
-    text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
 @mixin placeholder {
@@ -28,12 +28,12 @@
 }
 
 @mixin disable-highlight {
-    -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 @mixin animation($value) {

--- a/src/assets/scss/utilities/_utilities.scss
+++ b/src/assets/scss/utilities/_utilities.scss
@@ -1,2 +1,2 @@
-@import "functions",
-		"mixins";
+@import "functions";
+@import "mixins";

--- a/src/templates/index.hbs
+++ b/src/templates/index.hbs
@@ -1,5 +1,5 @@
 {{> header}}
 
 <p>
-    Hello World
+  Hello World
 </p>

--- a/src/templates/layouts/default.hbs
+++ b/src/templates/layouts/default.hbs
@@ -1,33 +1,30 @@
 <!doctype html>
 <html>
-	<head>
-		<meta charset="utf-8" />
-		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
-		<title></title>
-		<meta name="description" content="" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title></title>
+    <meta name="description" content="" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-		<!-- FONTS -->
+    <!-- Fonts -->
 
-		<!-- STYLES -->
-		<link rel="stylesheet" href="{{assets}}/css/screen.css" />
+    <!-- Styles -->
+    <link rel="stylesheet" href="{{assets}}/css/screen.css" />
 
-		<!--[if lt IE 9]>
-		    <link rel="stylesheet" href="{{assets}}/css/ie8.css" />
-		<![endif]-->
+    <!--[if lt IE 9]>
+      <link rel="stylesheet" href="{{assets}}/css/ie8.css" />
+    <![endif]-->
 
-		<!-- JAVASCRIPT -->
-		<script src="{{assets}}/js/lib/modernizr-2.8.0.min.js"></script>
-	</head>
-	<body>
+    <!-- Scripts -->
+    <script src="{{assets}}/js/lib/modernizr-2.8.0.min.js"></script>
+  </head>
+  <body>
+    {{> body}}
 
-		{{> body}}
-
-
-
-		<!-- JAVASCRIPT ASSETS -->
-		<script src="{{assets}}/js/lib/jquery-1.11.1.min.js"></script>
-		<script src="{{assets}}/js/vendor/min/plugins.js"></script>
-		<script src="{{assets}}/js/min/global.js"></script>
-	</body>
+    <!-- Scripts -->
+    <script src="{{assets}}/js/lib/jquery-1.11.1.min.js"></script>
+    <script src="{{assets}}/js/vendor/min/plugins.js"></script>
+    <script src="{{assets}}/js/min/global.js"></script>
+  </body>
 </html>

--- a/src/templates/partials/header.hbs
+++ b/src/templates/partials/header.hbs
@@ -1,3 +1,3 @@
 <header>
-	<h1>Front-end Boilerplate</h1>
+  <h1>Front-end Boilerplate</h1>
 </header>


### PR DESCRIPTION
This PR changes .editorconfig and files to use spaces instead of tabs. Most people have their IDEs set to use spaces which creates inconsistency issues with editors that respect the original .editorconfig indent settings.